### PR TITLE
Update JSON module import syntax and fix README copy path

### DIFF
--- a/packages/components/scripts/build_npm.ts
+++ b/packages/components/scripts/build_npm.ts
@@ -1,6 +1,6 @@
 import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
 
-import package_ from "./package.json" assert { type: "json" };
+import package_ from "./package.json" with { type: "json" };
 
 await emptyDir("./npm");
 
@@ -39,6 +39,6 @@ await build({
   postBuild() {
     // post build steps
     Deno.copyFileSync("src/LICENSE", "npm/LICENSE");
-    Deno.copyFileSync("src/README.md", "npm/README.md");
+    Deno.copyFileSync("README.md", "npm/README.md");
   },
 });


### PR DESCRIPTION
Changed the JSON module import syntax from `assert { type: 'json' }` to `with { type: 'json' }` as per the new standard. Also corrected the path for copying the README file during the post-build step to ensure it points to the correct location.